### PR TITLE
Lean pr testing 9304

### DIFF
--- a/Archive/MiuLanguage/DecisionSuf.lean
+++ b/Archive/MiuLanguage/DecisionSuf.lean
@@ -86,7 +86,7 @@ theorem der_of_der_append_replicate_U_even {z : Miustr} {m : ℕ}
   induction m with
   | zero =>
     revert h
-    rw [replicate, append_nil]; exact id
+    rw [replicate, append_nil]
   | succ k hk =>
     apply hk
     simp only [succ_mul, replicate_add] at h

--- a/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/Base.lean
@@ -355,9 +355,7 @@ theorem tendsto_logb_atTop_of_base_lt_one : Tendsto (logb b) atTop atBot := by
   intro a
   simp only [and_imp, sup_le_iff]
   intro ha
-  rw [logb_le_iff_le_rpow_of_base_lt_one b_pos b_lt_one]
-  · tauto
-  · exact lt_of_lt_of_le zero_lt_one ha
+  exact (logb_le_iff_le_rpow_of_base_lt_one b_pos b_lt_one (by positivity)).mpr
 
 end BPosAndBLtOne
 

--- a/Mathlib/CategoryTheory/Groupoid/Subgroupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid/Subgroupoid.lean
@@ -246,7 +246,7 @@ theorem inclusion_inj_on_objects {S T : Subgroupoid C} (h : S ≤ T) :
 theorem inclusion_faithful {S T : Subgroupoid C} (h : S ≤ T) (s t : S.objs) :
     Function.Injective fun f : s ⟶ t => (inclusion h).map f := fun ⟨f, hf⟩ ⟨g, hg⟩ => by
   -- Porting note: was `...; simpa only [Subtype.mk_eq_mk] using id`
-  dsimp only [inclusion]; rw [Subtype.mk_eq_mk, Subtype.mk_eq_mk]; exact id
+  dsimp only [inclusion]; rw [Subtype.mk_eq_mk, Subtype.mk_eq_mk]
 
 theorem inclusion_refl {S : Subgroupoid C} : inclusion (le_refl S) = 𝟭 S.objs :=
   Functor.hext (fun _ => rfl) fun _ _ _ => HEq.refl _

--- a/Mathlib/Data/Ordmap/Invariants.lean
+++ b/Mathlib/Data/Ordmap/Invariants.lean
@@ -149,7 +149,7 @@ instance Balanced.dec : DecidablePred (@Balanced α)
 
 @[symm]
 theorem BalancedSz.symm {l r : ℕ} : BalancedSz l r → BalancedSz r l :=
-  Or.imp (by rw [add_comm]; exact id) And.symm
+  Or.imp (by rw [add_comm]) And.symm
 
 theorem balancedSz_zero {l : ℕ} : BalancedSz l 0 ↔ l ≤ 1 := by
   simp +contextual [BalancedSz]

--- a/Mathlib/Data/PNat/Prime.lean
+++ b/Mathlib/Data/PNat/Prime.lean
@@ -215,7 +215,6 @@ theorem gcd_one {n : ℕ+} : gcd n 1 = 1 := by
 theorem Coprime.symm {m n : ℕ+} : m.Coprime n → n.Coprime m := by
   unfold Coprime
   rw [gcd_comm]
-  simp
 
 @[simp]
 theorem one_coprime {n : ℕ+} : (1 : ℕ+).Coprime n :=

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -383,7 +383,6 @@ theorem castHom_injective : Function.Injective (ZMod.castHom (dvd_refl n) R) := 
   intro x
   obtain ⟨k, rfl⟩ := ZMod.intCast_surjective x
   rw [map_intCast, CharP.intCast_eq_zero_iff R n, CharP.intCast_eq_zero_iff (ZMod n) n]
-  exact id
 
 theorem castHom_bijective [Fintype R] (h : Fintype.card R = n) :
     Function.Bijective (ZMod.castHom (dvd_refl n) R) := by

--- a/Mathlib/LinearAlgebra/Dual/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/Dual/Lemmas.lean
@@ -812,7 +812,6 @@ theorem dualCopairing_nondegenerate (W : Subspace K V₁) : W.dualCopairing.Nond
   · rintro ⟨x⟩
     simp only [Quotient.quot_mk_eq_mk, dualCopairing_apply, Quotient.mk_eq_zero]
     rw [← forall_mem_dualAnnihilator_apply_eq_zero_iff, SetLike.forall]
-    exact id
 
 -- Argument from https://math.stackexchange.com/a/2423263/172988
 theorem dualAnnihilator_inf_eq (W W' : Subspace K V₁) :

--- a/Mathlib/LinearAlgebra/Dual/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/Dual/Lemmas.lean
@@ -812,6 +812,7 @@ theorem dualCopairing_nondegenerate (W : Subspace K V₁) : W.dualCopairing.Nond
   · rintro ⟨x⟩
     simp only [Quotient.quot_mk_eq_mk, dualCopairing_apply, Quotient.mk_eq_zero]
     rw [← forall_mem_dualAnnihilator_apply_eq_zero_iff, SetLike.forall]
+    exact id
 
 -- Argument from https://math.stackexchange.com/a/2423263/172988
 theorem dualAnnihilator_inf_eq (W W' : Subspace K V₁) :

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -285,7 +285,7 @@ theorem IsSemisimple.of_mem_adjoin_pair {a : End K M} (ha : a ∈ Algebra.adjoin
   let φ : S →ₐ[K] End K M := Ideal.Quotient.liftₐ _ (eval₂AlgHom' (Ideal.Quotient.liftₐ _ (aeval f)
     fun a ↦ ?_) g ?_) ((Ideal.span_singleton_le_iff_mem _).mpr ?_ : _ ≤ RingHom.ker _)
   rotate_left 1
-  · rw [Ideal.span, ← minpoly.ker_aeval_eq_span_minpoly]; exact id
+  · rw [Ideal.span, ← minpoly.ker_aeval_eq_span_minpoly]
   · rintro ⟨p⟩; exact p.induction_on (fun k ↦ by simp [R, Algebra.commute_algebraMap_left])
       (fun p q hp hq ↦ by simpa [R] using hp.add_left hq)
       fun n k ↦ by simpa [R, pow_succ, ← mul_assoc _ _ X] using (·.mul_left comm)

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -285,7 +285,7 @@ theorem IsSemisimple.of_mem_adjoin_pair {a : End K M} (ha : a ∈ Algebra.adjoin
   let φ : S →ₐ[K] End K M := Ideal.Quotient.liftₐ _ (eval₂AlgHom' (Ideal.Quotient.liftₐ _ (aeval f)
     fun a ↦ ?_) g ?_) ((Ideal.span_singleton_le_iff_mem _).mpr ?_ : _ ≤ RingHom.ker _)
   rotate_left 1
-  · rw [Ideal.span, ← minpoly.ker_aeval_eq_span_minpoly]
+  · rw [Ideal.span, ← minpoly.ker_aeval_eq_span_minpoly, RingHom.mem_ker]
   · rintro ⟨p⟩; exact p.induction_on (fun k ↦ by simp [R, Algebra.commute_algebraMap_left])
       (fun p q hp hq ↦ by simpa [R] using hp.add_left hq)
       fun n k ↦ by simpa [R, pow_succ, ← mul_assoc _ _ X] using (·.mul_left comm)

--- a/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFuncDenseLp.lean
@@ -562,7 +562,7 @@ theorem add_toSimpleFunc (f g : Lp.simpleFunc E p μ) :
   filter_upwards [toSimpleFunc_eq_toFun (f + g), toSimpleFunc_eq_toFun f,
     toSimpleFunc_eq_toFun g, Lp.coeFn_add (f : Lp E p μ) g] with _
   simp only [AddSubgroup.coe_add, Pi.add_apply]
-  iterate 4 intro h; rw [h]
+  iterate 3 intro h; rw [h]
 
 theorem neg_toSimpleFunc (f : Lp.simpleFunc E p μ) : toSimpleFunc (-f) =ᵐ[μ] -toSimpleFunc f := by
   filter_upwards [toSimpleFunc_eq_toFun (-f), toSimpleFunc_eq_toFun f,

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -208,7 +208,7 @@ theorem measure_mul_right_ne_zero (h2s : μ s ≠ 0) (y : G) : μ ((fun x => x *
 @[to_additive]
 theorem absolutelyContinuous_map_mul_right (g : G) : μ ≪ map (· * g) μ := by
   refine AbsolutelyContinuous.mk fun s hs => ?_
-  rw [map_apply (measurable_mul_const g) hs, measure_mul_right_null]; exact id
+  rw [map_apply (measurable_mul_const g) hs, measure_mul_right_null]
 
 @[to_additive]
 theorem absolutelyContinuous_map_div_left (g : G) : μ ≪ map (fun h => g / h) μ := by
@@ -467,7 +467,7 @@ This should not be confused with `(measurePreserving_add_right μ g).quasiMeasur
 theorem quasiMeasurePreserving_mul_right [IsMulLeftInvariant μ] (g : G) :
     QuasiMeasurePreserving (fun h : G => h * g) μ μ := by
   refine ⟨measurable_mul_const g, AbsolutelyContinuous.mk fun s hs => ?_⟩
-  rw [map_apply (measurable_mul_const g) hs, measure_mul_right_null]; exact id
+  rw [map_apply (measurable_mul_const g) hs, measure_mul_right_null]
 
 /-- A *right*-invariant measure is quasi-preserved by *left*-multiplication.
 This should not be confused with `(measurePreserving_mul_left μ g).quasiMeasurePreserving`. -/

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -538,7 +538,6 @@ theorem integrableOn_Iic_of_intervalIntegral_norm_bounded (I b : ℝ)
   refine hφ.integrable_of_integral_norm_bounded I hfi (h.mp ?_)
   filter_upwards [ha.eventually (eventually_le_atBot b)] with i hai
   rw [intervalIntegral.integral_of_le hai, Measure.restrict_restrict (hφ.measurableSet i)]
-  exact id
 
 /-- If `f` is integrable on intervals `Ioc (a i) b`,
 where `a i` tends to -∞, and
@@ -562,7 +561,6 @@ theorem integrableOn_Ioi_of_intervalIntegral_norm_bounded (I a : ℝ)
   filter_upwards [hb.eventually (eventually_ge_atTop a)] with i hbi
   rw [intervalIntegral.integral_of_le hbi, Measure.restrict_restrict (hφ.measurableSet i),
     inter_comm]
-  exact id
 
 /-- If `f` is integrable on intervals `Ioc a (b i)`,
 where `b i` tends to ∞, and

--- a/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegralEqImproper.lean
@@ -537,7 +537,8 @@ theorem integrableOn_Iic_of_intervalIntegral_norm_bounded (I b : ℝ)
     exact hfi i
   refine hφ.integrable_of_integral_norm_bounded I hfi (h.mp ?_)
   filter_upwards [ha.eventually (eventually_le_atBot b)] with i hai
-  rw [intervalIntegral.integral_of_le hai, Measure.restrict_restrict (hφ.measurableSet i)]
+  rw [intervalIntegral.integral_of_le hai, Measure.restrict_restrict (hφ.measurableSet i),
+    Ioi_inter_Iic]
 
 /-- If `f` is integrable on intervals `Ioc (a i) b`,
 where `a i` tends to -∞, and
@@ -560,7 +561,7 @@ theorem integrableOn_Ioi_of_intervalIntegral_norm_bounded (I a : ℝ)
   refine hφ.integrable_of_integral_norm_bounded I hfi (h.mp ?_)
   filter_upwards [hb.eventually (eventually_ge_atTop a)] with i hbi
   rw [intervalIntegral.integral_of_le hbi, Measure.restrict_restrict (hφ.measurableSet i),
-    inter_comm]
+    Iic_inter_Ioi]
 
 /-- If `f` is integrable on intervals `Ioc a (b i)`,
 where `b i` tends to ∞, and

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -972,7 +972,6 @@ theorem map_restrict_ae_le_map_indicator_ae [Zero β] (hs : MeasurableSet s) :
   intro t
   by_cases ht : (0 : β) ∈ t
   · rw [mem_map_indicator_ae_iff_mem_map_restrict_ae_of_zero_mem ht hs]
-    exact id
   rw [mem_map_indicator_ae_iff_of_zero_notMem ht, mem_map_restrict_ae_iff hs]
   exact fun h => measure_mono_null (Set.inter_subset_left.trans Set.subset_union_left) h
 

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -309,7 +309,6 @@ theorem mem_generatePiSystem_iUnion_elim' {α β} {g : β → Set (Set α)} {s :
         have h2 := h1 b h_b h_b_in_T
         revert h2
         rw [Subtype.val_injective.extend_apply]
-        apply id
   · intros b h_b
     simp_rw [Finset.mem_image, Subtype.exists, exists_and_right, exists_eq_right]
       at h_b

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -489,8 +489,7 @@ theorem coe_inj {q r : ℚ} : (↑q : ℚ_[p]) = ↑r ↔ q = r :=
 instance : CharZero ℚ_[p] :=
   ⟨fun m n ↦ by
     rw [← Rat.cast_natCast]
-    norm_cast
-    exact id⟩
+    norm_cast⟩
 
 @[norm_cast]
 theorem coe_add : ∀ {x y : ℚ}, (↑(x + y) : ℚ_[p]) = ↑x + ↑y :=

--- a/Mathlib/SetTheory/Cardinal/Arithmetic.lean
+++ b/Mathlib/SetTheory/Cardinal/Arithmetic.lean
@@ -219,7 +219,6 @@ theorem mul_eq_left_iff {a b : Cardinal} : a * b = a ↔ max ℵ₀ b ≤ a ∧ 
     apply fun h2b => ne_of_gt _ h
     conv_rhs => left; rw [← mul_one n]
     rw [Nat.mul_lt_mul_left]
-    · exact id
     apply Nat.lt_of_succ_le h2a
   · rintro (⟨⟨ha, hab⟩, hb⟩ | rfl | rfl)
     · rw [mul_eq_max_of_aleph0_le_left ha hb, max_eq_left hab]

--- a/Mathlib/SetTheory/Surreal/Multiplication.lean
+++ b/Mathlib/SetTheory/Surreal/Multiplication.lean
@@ -111,9 +111,7 @@ lemma P2_neg_left : P2 x₁ x₂ y ↔ P2 (-x₂) (-x₁) y := by
   rw [P2, P2]
   constructor
   · rw [quot_neg_mul, quot_neg_mul, eq_comm, neg_inj, neg_equiv_neg_iff, PGame.equiv_comm]
-    exact (· ·)
   · rw [PGame.equiv_comm, neg_equiv_neg_iff, quot_neg_mul, quot_neg_mul, neg_inj, eq_comm]
-    exact (· ·)
 
 lemma P2_neg_right : P2 x₁ x₂ y ↔ P2 x₁ x₂ (-y) := by
   rw [P2, P2, quot_mul_neg, quot_mul_neg, neg_inj]
@@ -382,7 +380,6 @@ lemma mulOptionsLTMul_of_numeric (hn : (x * y).Numeric) :
     all_goals
       rw [lt_neg]
       first | rw [quot_mul_neg] | rw [quot_neg_mul]
-      exact id
 
 /-- A condition just enough to deduce P3, which will always be used with `x'` being a left
   option of `x₂`. When `y₁` is a left option of `y₂`, it can be deduced from induction hypotheses

--- a/Mathlib/SetTheory/ZFC/Ordinal.lean
+++ b/Mathlib/SetTheory/ZFC/Ordinal.lean
@@ -190,7 +190,6 @@ theorem not_subset_iff_mem (hx : x.IsOrdinal) (hy : y.IsOrdinal) : ¬ x ⊆ y �
 
 theorem mem_or_subset (hx : x.IsOrdinal) (hy : y.IsOrdinal) : x ∈ y ∨ y ⊆ x := by
   rw [or_iff_not_imp_left, notMem_iff_subset hx hy]
-  exact id
 
 theorem subset_total (hx : x.IsOrdinal) (hy : y.IsOrdinal) : x ⊆ y ∨ y ⊆ x := by
   obtain h | h := mem_or_subset hx hy

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -279,7 +279,6 @@ example (n : Nat) (h : p → n=1) (h' : p) : n = 1 := by
 
 example (n : Nat) (h : p → n=1) (h' : r → s) : p ∧ r → n = 1 ∧ s := by
   apply_rw [h, h']
-  exact id
 
 example (n : Nat) (h : p → n=1) (h' : r → s) : p ∧ r → n = 1 ∧ s := by
   grw [h]


### PR DESCRIPTION
`rfl` now closes the goal `p -> p`, so we fix some proofs

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
