### PR TITLE
chore(Cache): use FRO cache

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -210,8 +210,8 @@ def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
   IO.println s!"Using cache from {remoteName}: {repo}"
   return {repo := repo, useFirst := false}
 
--- FRO cache is flaky so disable until we work out the kinks: https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/The.20cache.20doesn't.20work/near/411058849
-def useFROCache : Bool := false
+-- FRO cache may be flaky: https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/The.20cache.20doesn't.20work/near/411058849
+def useFROCache : Bool := true
 
 /-- Public URL for mathlib cache -/
 def URL : String :=


### PR DESCRIPTION
Switches Cache to use the FRO Cloudflare storage instead of Azure. 

The last attempt to do this encountered some flakiness, so the plan is try testing it here on `nightly-testing` and debug any issues so that this switch can be made on Mathlib proper. 

Marked as draft until this switch is further coordinated with the Mathlib team. It also needs the CI to be updated with the relevant secrets.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
