### PR TITLE
chore: adapt `to_additive` to lean4#9966

### DIFF
--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -996,7 +996,6 @@ def proceedFields (src tgt : Name) : CoreM Unit := do
     | some (ConstantInfo.inductInfo { ctors, .. }) => return ctors.toArray
     | _ => pure #[]
 
-open Tactic.TryThis in
 /-- Elaboration of the configuration options for `to_additive`. -/
 def elabToAdditive : Syntax → CoreM Config
   | `(attr| to_additive%$tk $[?%$trace]? $existing?
@@ -1034,22 +1033,17 @@ def elabToAdditive : Syntax → CoreM Config
       | `(str|$doc:str) => open Linter in do
         -- Deprecate `str` docstring syntax (since := "2025-08-12")
         if getLinterValue linter.deprecated (← getLinterOptions) then
+          let hintSuggestion := {
+            diffGranularity := .none
+            toTryThisSuggestion := { suggestion := "/-- " ++ doc.getString.trim ++ " -/" }
+          }
+          let sugg ← Hint.mkSuggestionsMessage #[hintSuggestion] doc
+            (codeActionPrefix? := "Update to: ") (forceList := false)
           logWarningAt doc <| .tagged ``Linter.deprecatedAttr
             m!"String syntax for `to_additive` docstrings is deprecated: Use \
-              docstring syntax instead (e.g. `@[to_additive /-- example -/]`)"
-          /-
-          #adaptation_note 2025-08-27
-          `addSuggestionCore` was removed in https://github.com/leanprover/lean4/pull/9966
-          As far as I can see, the replacement functionality is only available in `MetaM`,
-          rather than `CoreM`, so some redesign will be needed here.
-          -/
-          -- addSuggestionCore doc
-          --   (header := "Update deprecated syntax to:\n")
-          --   (codeActionPrefix? := "Update to: ")
-          --   (isInline := true)
-          --   #[{
-          --     suggestion := "/-- " ++ doc.getString.trim ++ " -/"
-          --   }]
+              docstring syntax instead (e.g. `@[to_additive /-- example -/]`)\n\
+              \n\
+              Update deprecated syntax to:{sugg}"
         return doc.getString
       | `(docComment|$doc:docComment) => do
         -- TODO: rely on `addDocString`s call to `validateDocComment` after removing `str` support

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -567,8 +567,10 @@ run_cmd
   logInfo doc
 
 /--
-warning: String syntax for `to_additive` docstrings is deprecated:
-Use docstring syntax instead (e.g. `@[to_additive /-- example -/]`)
+warning: String syntax for `to_additive` docstrings is deprecated: Use docstring syntax instead (e.g. `@[to_additive /-- example -/]`)
+
+Update deprecated syntax to:
+  /-- (via `str` syntax) I am an additive docstring! -/
 -/
 #guard_msgs in
 @[to_additive "(via `str` syntax) I am an additive docstring!"]


### PR DESCRIPTION
Uses `Hint.mkSuggestionsMessage` in place of `addSuggestionCore`. This no longer requires `open private`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
