### PR TITLE
chore: adapt `hint` tactic to lean4#9966

### DIFF
--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -63,15 +63,18 @@ elab (name := registerHintStx)
 initialize
   Batteries.Linter.UnreachableTactic.ignoreTacticKindsRef.modify fun s => s.insert ``registerHintStx
 
-
+/--
+Extracts the `MessageData` from the first clickable `Try This:` diff widget in the message.
+Preserves (only) contexts and tags.
+-/
 private def getFirstTryThisFromMessage? : MessageData → Option MessageData
 | .ofWidget w msg => if w.id == ``Meta.Hint.tryThisDiffWidget then msg else none
-| .withContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withContext ctx
-| .withNamingContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withNamingContext ctx
 | .nest _ msg
 | .group msg => getFirstTryThisFromMessage? msg
 | .compose msg₁ msg₂ => getFirstTryThisFromMessage? msg₁ <|> getFirstTryThisFromMessage? msg₂
-| .tagged tag msg => (getFirstTryThisFromMessage? msg).map (.tagged tag)
+| .withContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withContext ctx
+| .withNamingContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withNamingContext ctx
+| .tagged tag msg => (getFirstTryThisFromMessage? msg).map <| .tagged tag
 | .ofFormatWithInfos _ | .ofGoal _ | .trace .. | .ofLazy .. => none
 
 /--

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -80,13 +80,19 @@ def suggestion (tac : TSyntax `tactic) (msgs : MessageLog := {}) : TacticM Sugge
       let e ← PrettyPrinter.ppExpr (← instantiateMVars (← g.getType))
       str := str ++ Format.pretty ("\n⊢ " ++ e)
     pure (some str)
-  let style? := if goals.isEmpty then some .success else none
+  /-
+  #adaptation_note 2025-08-27
+  Suggestion styling was deprecated in lean4#9966.
+  We use emojis for now instead.
+  -/
+  -- let style? := if goals.isEmpty then some .success else none
+  let preInfo? := if goals.isEmpty then some "🎉" else none
   let msg? ← msgs.toList.findM? fun m => do pure <|
-    m.severity == MessageSeverity.information && (← m.data.toString).startsWith "Try this: "
+    m.severity == MessageSeverity.information && (← m.data.toString).startsWith "Try this:"
   let suggestion ← match msg? with
   | some m => pure <| SuggestionText.string ((← m.data.toString).drop 10)
   | none => pure <| SuggestionText.tsyntax tac
-  return { suggestion, postInfo?, style? }
+  return { preInfo?, suggestion, postInfo? }
 
 /-- Run a tactic, returning any new messages rather than adding them to the message log. -/
 def withMessageLog (t : TacticM Unit) : TacticM MessageLog := do

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -63,6 +63,17 @@ elab (name := registerHintStx)
 initialize
   Batteries.Linter.UnreachableTactic.ignoreTacticKindsRef.modify fun s => s.insert ``registerHintStx
 
+
+private def getFirstTryThisFromMessage? : MessageData → Option MessageData
+| .ofWidget w msg => if w.id == ``Meta.Hint.tryThisDiffWidget then msg else none
+| .withContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withContext ctx
+| .withNamingContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withNamingContext ctx
+| .nest _ msg
+| .group msg => getFirstTryThisFromMessage? msg
+| .compose msg₁ msg₂ => getFirstTryThisFromMessage? msg₁ <|> getFirstTryThisFromMessage? msg₂
+| .tagged tag msg => (getFirstTryThisFromMessage? msg).map (.tagged tag)
+| .ofFormatWithInfos _ | .ofGoal _ | .trace .. | .ofLazy .. => none
+
 /--
 Construct a suggestion for a tactic.
 * Check the passed `MessageLog` for an info message beginning with "Try this: ".
@@ -87,10 +98,9 @@ def suggestion (tac : TSyntax `tactic) (msgs : MessageLog := {}) : TacticM Sugge
   -/
   -- let style? := if goals.isEmpty then some .success else none
   let preInfo? := if goals.isEmpty then some "🎉 " else none
-  let msg? ← msgs.toList.findM? fun m => do pure <|
-    m.severity == MessageSeverity.information && (← m.data.toString).startsWith "Try this:"
+  let msg? : Option MessageData := msgs.toList.firstM (getFirstTryThisFromMessage? ·.data)
   let suggestion ← match msg? with
-  | some m => pure <| SuggestionText.string ((← m.data.toString).drop 10)
+  | some m => pure <| SuggestionText.string (← m.toString)
   | none => pure <| SuggestionText.tsyntax tac
   return { preInfo?, suggestion, postInfo? }
 

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -86,7 +86,7 @@ def suggestion (tac : TSyntax `tactic) (msgs : MessageLog := {}) : TacticM Sugge
   We use emojis for now instead.
   -/
   -- let style? := if goals.isEmpty then some .success else none
-  let preInfo? := if goals.isEmpty then some "🎉" else none
+  let preInfo? := if goals.isEmpty then some "🎉 " else none
   let msg? ← msgs.toList.findM? fun m => do pure <|
     m.severity == MessageSeverity.information && (← m.data.toString).startsWith "Try this:"
   let suggestion ← match msg? with

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -68,14 +68,14 @@ Extracts the `MessageData` from the first clickable `Try This:` diff widget in t
 Preserves (only) contexts and tags.
 -/
 private def getFirstTryThisFromMessage? : MessageData → Option MessageData
-| .ofWidget w msg => if w.id == ``Meta.Hint.tryThisDiffWidget then msg else none
-| .nest _ msg
-| .group msg => getFirstTryThisFromMessage? msg
-| .compose msg₁ msg₂ => getFirstTryThisFromMessage? msg₁ <|> getFirstTryThisFromMessage? msg₂
-| .withContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withContext ctx
-| .withNamingContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withNamingContext ctx
-| .tagged tag msg => (getFirstTryThisFromMessage? msg).map <| .tagged tag
-| .ofFormatWithInfos _ | .ofGoal _ | .trace .. | .ofLazy .. => none
+  | .ofWidget w msg => if w.id == ``Meta.Hint.tryThisDiffWidget then msg else none
+  | .nest _ msg
+  | .group msg => getFirstTryThisFromMessage? msg
+  | .compose msg₁ msg₂ => getFirstTryThisFromMessage? msg₁ <|> getFirstTryThisFromMessage? msg₂
+  | .withContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withContext ctx
+  | .withNamingContext ctx msg => (getFirstTryThisFromMessage? msg).map <| .withNamingContext ctx
+  | .tagged tag msg => (getFirstTryThisFromMessage? msg).map <| .tagged tag
+  | .ofFormatWithInfos _ | .ofGoal _ | .trace .. | .ofLazy .. => none
 
 /--
 Construct a suggestion for a tactic.

--- a/MathlibTest/hint.lean
+++ b/MathlibTest/hint.lean
@@ -9,58 +9,77 @@ import Mathlib.Tactic.TautoSet
 
 /--
 info: Try these:
-• linarith
+  • 🎉 linarith
 -/
 #guard_msgs in
 example (h : 1 < 0) : False := by hint
 
 /--
 info: Try these:
-• exact f p
-• norm_num
+  • 🎉 exact f p
+  • norm_num
+    Remaining subgoals:
+    ⊢ Q
 -/
 #guard_msgs in
 example {P Q : Prop} (p : P) (f : P → Q) : Q := by hint
 
 /--
 info: Try these:
-• simp_all only [and_self]
-• norm_num
+  • 🎉 simp_all only [and_self]
+  • norm_num
+    Remaining subgoals:
+    ⊢ Q ∧ P ∧ R
 -/
 #guard_msgs in
 example {P Q R : Prop} (x : P ∧ Q ∧ R ∧ R) : Q ∧ P ∧ R := by hint
 
 /--
 info: Try these:
-• linarith
-• field_simp
+  • 🎉 linarith
+  • field_simp
+    Remaining subgoals:
+    ⊢ a ≤ b
 -/
 #guard_msgs in
 example {a b : ℚ} (h : a < b) : ¬ b < a := by hint
 
 /--
 info: Try these:
-• ring
+  • 🎉 ring
 -/
 #guard_msgs in
 example : 37^2 - 35^2 = 72 * 2 := by hint
 
 /--
 info: Try these:
-• decide
-• ring_nf
-• norm_num
+  • 🎉 decide
+  • ring_nf
+    Remaining subgoals:
+    ⊢ Nat.Prime 37
+  • norm_num
+    Remaining subgoals:
+    ⊢ Nat.Prime 37
 -/
 #guard_msgs in
 example : Nat.Prime 37 := by hint
 
 /--
 info: Try these:
-• aesop
-• ring_nf
-• field_simp
-• norm_num
-• simp_all only [zero_le, and_true]
+  • 🎉 aesop
+  • ring_nf
+    Remaining subgoals:
+    ⊢ ∃ x, P x ∧ 0 ≤ x
+  • field_simp
+    Remaining subgoals:
+    ⊢ ∃ x, P x
+  • norm_num
+    Remaining subgoals:
+    ⊢ ∃ x, P x
+  • simp_all only [zero_le,
+      and_true]
+    Remaining subgoals:
+    ⊢ ∃ x, P x
 -/
 #guard_msgs in
 example {P : Nat → Prop} (h : { x // P x }) : ∃ x, P x ∧ 0 ≤ x := by hint
@@ -79,8 +98,7 @@ register_hint long_trivial
 
 /--
 info: Try these:
-• this_is_a_multiline_exact
-    trivial
+  • 🎉 long_trivial
 -/
 #guard_msgs in
 example : True := by
@@ -94,18 +112,28 @@ register_hint tauto_set
 
 /--
 info: Try these:
-• tauto_set
+  • 🎉 tauto_set
 -/
 #guard_msgs in
 example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A := by hint
 
 /--
 info: Try these:
-• aesop
-• ring_nf
-• field_simp
-• norm_num
-• simp_all only [Nat.not_ofNat_le_one]
+  • aesop
+    Remaining subgoals:
+    ⊢ False
+  • ring_nf
+    Remaining subgoals:
+    ⊢ 2 ≤ 1
+  • field_simp
+    Remaining subgoals:
+    ⊢ False
+  • norm_num
+    Remaining subgoals:
+    ⊢ False
+  • simp_all only [Nat.not_ofNat_le_one]
+    Remaining subgoals:
+    ⊢ False
 ---
 warning: declaration uses 'sorry'
 -/
@@ -117,7 +145,7 @@ end tauto_set
 section compute_degree
 /--
 info: Try these:
-• compute_degree
+  • 🎉 compute_degree
 -/
 #guard_msgs in
 open Polynomial in
@@ -127,8 +155,10 @@ end compute_degree
 section field_simp
 /--
 info: Try these:
-• field_simp
-• ring_nf
+  • 🎉 field_simp
+  • ring_nf
+    Remaining subgoals:
+    ⊢ a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁
 -/
 #guard_msgs in
 example (R : Type) (a b : R) [CommRing R] (u₁ : Rˣ) : a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁ := by hint
@@ -137,7 +167,7 @@ end field_simp
 section finiteness
 /--
 info: Try these:
-• finiteness
+  • 🎉 finiteness
 -/
 #guard_msgs in
 open ENNReal in


### PR DESCRIPTION
* Uses a :tada: emoji in place of "success" styling in `hint`, since suggestion styling was deprecated in lean4#9966
* Changes how `hint` finds the try this suggestion
* Not due to changes in this PR: apparently "Remaining goals" `postInfo?` works now

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
