### PR TITLE
feat: add test for `register_try?_tactic`

### DIFF
--- a/Mathlib/Tactic/Linter/UnusedTactic.lean
+++ b/Mathlib/Tactic/Linter/UnusedTactic.lean
@@ -96,6 +96,7 @@ initialize ignoreTacticKindsRef : IO.Ref NameHashSet ←
     ``Lean.Parser.Command.mixfix,
     ``Lean.Parser.Tactic.discharger,
     ``Lean.Parser.Tactic.Conv.conv,
+    ``Lean.Parser.Command.registerTryTactic,
     `Batteries.Tactic.seq_focus,
     `Mathlib.Tactic.Hint.registerHintStx,
     `Mathlib.Tactic.LinearCombination.linearCombination,

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -65,7 +65,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "5eb9119641f7afb4b1cb79694a848f48ac849941",
+   "rev": "d933c28e7e12434d6a56c5887f30698ac13eec92",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "nightly-testing",


### PR DESCRIPTION
Ensures that the new `register_try?_tactic` command works in Mathlib.