### PR TITLE
chore: fix deprecation warnings

### DIFF
--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -615,7 +615,7 @@ lemma IsChain.iterate_eq_of_apply_eq {α : Type*} {f : α → α} {l : List α}
   | zero => rfl
   | succ i h =>
     rw [Function.iterate_succ', Function.comp_apply, h (by lia)]
-    rw [List.isChain_iff_get] at hl
+    rw [List.isChain_iff_getElem] at hl
     apply hl
 
 @[deprecated (since := "2025-09-24")]

--- a/Mathlib/Data/List/ChainOfFn.lean
+++ b/Mathlib/Data/List/ChainOfFn.lean
@@ -22,7 +22,7 @@ namespace List
 
 lemma isChain_ofFn {α : Type*} {n : ℕ} {f : Fin n → α} {r : α → α → Prop} :
     (ofFn f).IsChain r ↔ ∀ (i) (hi : i + 1 < n), r (f ⟨i, lt_of_succ_lt hi⟩) (f ⟨i + 1, hi⟩) := by
-  simp_rw [isChain_iff_get, get_ofFn, length_ofFn]
+  simp_rw [isChain_iff_getElem, getElem_ofFn, length_ofFn]
   exact ⟨fun h i hi ↦ h i (by lia), fun h i hi ↦ h i (by lia)⟩
 
 @[deprecated (since := "2025-09-24")] alias chain'_ofFn := isChain_ofFn

--- a/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/Mathlib/RingTheory/Polynomial/Resultant/Basic.lean
@@ -910,7 +910,7 @@ lemma isUnit_resultant_iff_isCoprime {f g : R[X]} (hf : f.Monic) :
         rw [add_comm, ← hf.natDegree_mul' hb0, mul_comm f] at H
         have := natDegree_add_eq_left_of_natDegree_lt H
         simp only [e, natDegree_one] at this
-        cutsat
+        lia
 
 lemma resultant_eq_zero_iff {K : Type*} [Field K] {f g : K[X]} :
     resultant f g = 0 ↔ (f ≠ 0 ∨ g ≠ 0) ∧ ¬ IsCoprime f g := by


### PR DESCRIPTION
## Summary

- Replace deprecated `isChain_iff_get` with `isChain_iff_getElem` in `Mathlib/Data/List/Chain.lean` and `Mathlib/Data/List/ChainOfFn.lean`
- Replace deprecated `cutsat` with `lia` in `Mathlib/RingTheory/Polynomial/Resultant/Basic.lean`

These warnings are currently causing the nightly-testing CI to fail.

🤖 Prepared with Claude Code