### PR TITLE
Fix Mathlib.LinearAlgebra.SymplecticGroup

### DIFF
--- a/Mathlib/LinearAlgebra/SymplecticGroup.lean
+++ b/Mathlib/LinearAlgebra/SymplecticGroup.lean
@@ -59,11 +59,13 @@ theorem J_inv : (J l R)⁻¹ = -J l R := by
   exact neg_neg 1
 
 theorem J_det_mul_J_det : det (J l R) * det (J l R) = 1 := by
-  sorry
-  -- rw [← det_mul, J_squared, ← one_smul R (-1 : Matrix _ _ R), smul_neg, ← neg_smul, det_smul,
-  --   Fintype.card_sum, det_one, mul_one]
-  -- apply Even.neg_one_pow
-  -- exact Even.add_self _
+  #adaptation_note /-- Needed after leanprover/lean4#12564 -/
+  letI inst : Module R (Matrix (l ⊕ l) (l ⊕ l) R) := inferInstance
+  have := @neg_smul R (Matrix (l ⊕ l) (l ⊕ l) R) _ _ inst (1 : R) (1 : Matrix (l ⊕ l) (l ⊕ l) R)
+  rw [← det_mul, J_squared, ← one_smul R (-1 : Matrix _ _ R), smul_neg, ← this, det_smul,
+    Fintype.card_sum, det_one, mul_one]
+  apply Even.neg_one_pow
+  exact Even.add_self _
 
 theorem isUnit_det_J : IsUnit (det (J l R)) :=
   isUnit_iff_exists_inv.mpr ⟨det (J l R), J_det_mul_J_det _ _⟩
@@ -163,15 +165,19 @@ instance hasInv : Inv (symplecticGroup l R) where
 theorem coe_inv (A : symplecticGroup l R) : (↑A⁻¹ : Matrix _ _ _) = (-J l R) * (↑A)ᵀ * J l R := rfl
 
 theorem inv_left_mul_aux (hA : A ∈ symplecticGroup l R) : -(J l R * Aᵀ * J l R * A) = 1 :=
+  #adaptation_note /-- Needed after leanprover/lean4#12564 -/
+  letI inst : Module R (Matrix (l ⊕ l) (l ⊕ l) R) := inferInstance
+  have ns := @neg_smul R (Matrix (l ⊕ l) (l ⊕ l) R) _ _ inst (1 : R)
+  have nsn := @neg_smul_neg R (Matrix (l ⊕ l) (l ⊕ l) R) _ _ inst (1 : R)
   calc
     -(J l R * Aᵀ * J l R * A) = (-J l R) * (Aᵀ * J l R * A) := by
       simp only [Matrix.mul_assoc, Matrix.neg_mul]
     _ = (-J l R) * J l R := by
       rw [mem_iff'] at hA
       rw [hA]
-    _ = (-1 : R) • (J l R * J l R) := by sorry -- simp only [Matrix.neg_mul, neg_smul, one_smul]
+    _ = (-1 : R) • (J l R * J l R) := by simp only [Matrix.neg_mul, ns, one_smul]
     _ = (-1 : R) • (-1 : Matrix _ _ _) := by rw [J_squared]
-    _ = 1 := by sorry -- simp only [neg_smul_neg, one_smul]
+    _ = 1 := by simp only [nsn, one_smul]
 
 theorem coe_inv' (A : symplecticGroup l R) : (↑A⁻¹ : Matrix (l ⊕ l) (l ⊕ l) R) = (↑A)⁻¹ := by
   refine (coe_inv A).trans (inv_eq_left_inv ?_).symm


### PR DESCRIPTION
Fixed up the two proofs that were broken due to the changes in https://github.com/leanprover/lean4/pull/12564.

The fixes both amount to introducing by hand an instance for Module R (Matrix (l ⊕ l) (l ⊕ l) R) so that neg_smul and neg_smul_neg can fire in the places with the sorrys

---
<!-- Your PR title will become the first line of the commit message.

In this box, the text above the `---` (if not empty) will be appended
to the commit message, and can be used to give additional context or
details. Please leave a blank newline before the `---`, otherwise GitHub
will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

When merging, all the commits will be squashed into a single commit
listing all co-authors.

Co-authors in the squash commit are gathered from two sources:

First, all authors of commits to this PR branch are included. Thus,
one way to add co-authors is to include at least one commit authored by
each co-author among the commits in the pull request. If necessary, you
may create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

Second, co-authors can also be listed in lines at the very bottom of
the commit message (that is, directly before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines
at the bottom of the commit message (before the `---`, and also before
any "Co-authored-by" lines) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
