### PR TITLE
fix: revert CompileInductive shim re-added by the 07-08 master merge (restore bump/v4.33.0 to green)

### DIFF
--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -258,23 +258,6 @@ compile_inductive% Option
 compile_def% False.recOn
 compile_def% Empty.recOn
 
--- In addition to the manual implementation below, we also have to override the `Float.val` and
--- `Float.mk` functions because these also have no implementation in core lean.
--- Because `floatSpec.float` is an opaque type, the identity function is as good an implementation
--- as any.
-private unsafe def Float.valUnsafe : Float → floatSpec.float := unsafeCast
-private unsafe def Float.mkUnsafe : floatSpec.float → Float := unsafeCast
-@[implemented_by Float.valUnsafe] private def Float.valImpl (x : Float) : floatSpec.float := x.1
-@[implemented_by Float.mkUnsafe] private def Float.mkImpl (x : floatSpec.float) : Float := ⟨x⟩
-
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
-@[csimp] private theorem Float.val_eq : @Float.val = Float.valImpl := rfl
-
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
-@[csimp] private theorem Float.mk_eq : @Float.mk = Float.mkImpl := rfl
-
 -- These types need manual implementations because the default implementation in `compileStruct`
 -- uses `Expr.proj` which has an invalid IR type.
 open Lean Meta Elab Mathlib.Util in


### PR DESCRIPTION
**Step 1 of catching `bump/v4.33.0` back up: fix the bad merge to restore a green baseline** (before merging master / advancing the toolchain).

## What was broken

`bump/v4.33.0` has been **red since 07-08**. The 07-08 master merge (`9bdb047c`) silently reverted `Mathlib/Util/CompileInductive.lean` toward master's version, **re-introducing the old `Float` shim** (`floatSpec.float` / `Float.val` / `Float.mk`). Those core identifiers don't exist on the `nightly-2026-07-07` toolchain, so the file no longer elaborates:

```
error: Mathlib/Util/CompileInductive.lean:265: Unknown identifier `floatSpec.float`
error: Mathlib/Util/CompileInductive.lean:272: Unknown constant `Float.val`
error: Mathlib/Util/CompileInductive.lean:276: Unknown constant `Float.mk`
```

`Float`/`Float32` are already compiled by the `run_cmd` loop just below, so the shim is pure dead-but-non-compiling leftover.

## The fix

Cherry-picks the fix the Lean team already made on `nightly-testing` for this exact clobber — `9afe4c91b08` "revert CompileInductive merge" (Rob23oba). The resulting file is **byte-identical to green `nightly-testing@281cecb6`**.

This is the same targeted revert/restore playbook used for past bad merges into bump branches (cf. `66d1b2c7fda` "restore … adaptations lost in master merge", `17ecbfaf0fa` "restore respectTransparency in Sites/Over"). A content check showed bump already carries those other restored adaptations — the `CompileInductive` shim was the only one still missing.

## Next steps (separate PRs)

2. Merge current `master` into `bump/v4.33.0` on this now-green base.
3. Advance the toolchain to the green 07-12 anchor (`nightly-testing@281cecb6`).
